### PR TITLE
Update to factorio 0.16

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -50,7 +50,7 @@ local function show_gui(player, item_name)
   -- add the desired plate type UI
   if player.gui.left[item_prefix] == nil then
     local plate_frame = player.gui.left.add{type = "frame", name = item_prefix, caption = {"textplates.text-plate-ui-title"}, direction = "vertical"}
-    local plates_table = plate_frame.add{type ="table", name = "plates_table", colspan = 6, style = "plates-table"}
+    local plates_table = plate_frame.add{type ="table", name = "plates_table", colspan = 8, style = "plates-table", column_count = 8 }
 
     for _, symbol in ipairs(textplates.symbols) do
       if not(symbol == "blank") then

--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
   "name": "textplates",
   "title": "Text Plates",
-  "version": "0.2.5",
-  "factorio_version": "0.15",
-  "dependencies": ["base >= 0.14.0"],
+  "version": "0.3.0",
+  "factorio_version": "0.16",
+  "dependencies": ["base >= 0.16.0"],
   "author": "Earendel",
   "description": "Text shaped metal plates for signs and labels. Letters, numbers and symbols. Iron, copper, large and small variants.",
   "homepage": "https://forums.factorio.com/viewtopic.php?f=93&t=34935",

--- a/prototype/styles.lua
+++ b/prototype/styles.lua
@@ -1,14 +1,14 @@
-data.raw["gui-style"]["default"]["plates-table"] =
+data.raw["gui-style"].default["plates-table"] =
 {
   type = "table_style",
   cell_spacing = 1,
   horizontal_spacing = 1,
   vertical_spacing = 1
 }
-data.raw["gui-style"]["default"]["plates-button"] =
+data.raw["gui-style"].default["plates-button"] =
 {
   type = "button_style",
-  parent = "button_style",
+  parent = "button",
   minimal_width = 32,
   minimal_height = 32,
   top_padding = 0,
@@ -16,10 +16,10 @@ data.raw["gui-style"]["default"]["plates-button"] =
   bottom_padding = 0,
   left_padding = 0,
 }
-data.raw["gui-style"]["default"]["plates-button-active"] =
+data.raw["gui-style"].default["plates-button-active"] =
 {
   type = "button_style",
-  parent = "button_style",
+  parent = "button",
   minimal_width = 32,
   minimal_height = 32,
   top_padding = 0,


### PR DESCRIPTION
+ ported mod to factorio 0.16
+ updated mod version to 0.3.0

Please note that the number of letter columns in the dialog is 8. It might have been 6 before, but I did not find a screenshot to be sure and it feels somewhat easier to use with 8 columns.
